### PR TITLE
Check for existence of removeDefs before setting default value

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,8 +8,11 @@ module.exports = plugin
 function plugin(options) {
 
   options = options || {};
-  options.removeDefs = options.removeDefs || true;
   options.selector = options.selector || 'img.svg';
+
+  if (!options.hasOwnProperty('removeDefs')) {
+    options.removeDefs = true;
+  }
 
   return function (files, metalsmith, done) {
     debug('running metalsmith-inline-svg');


### PR DESCRIPTION
Setting the `options.removeDefs` to false in the metalsmith configuration results in the code defaulting to true since the shorthand javascript evaluates to `false`.

To fix this I added a check to test for the existence of the prop before setting it.

I'm using this modification in my project and it is now properly skipping the code that removes the `<defs>` tags.
